### PR TITLE
Fix Strict Parsing of build number, fixes #17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,3 +36,4 @@ jobs:
         with:
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,3 +26,4 @@ jobs:
         with:
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Another [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html) impleme
 ### Create a version from scratch
 
 ```java
-Version version = new Release(1,0,0); // creates 1.0.0
+Version version = new Release(1, 0, 0); // creates 1.0.0
 ```
 
 ### Version math
@@ -58,7 +58,7 @@ String verString = new VersionSequence(version).toString();
 
 ## License
 
-Copyright 2023 dmfs GmbH
+Copyright 2024 dmfs GmbH
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id 'org.dmfs.gver' version '0.18.0'
+    id 'org.dmfs.gver' version '0.35.0'
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0' apply false
 }
 
@@ -32,9 +32,9 @@ gver {
             }
         }
         are minor when {
-            commitMessage contains("#feature\\b")
+            commitMessage contains(~/#feature\b/)
         }
-        otherwise patch
+        are patch otherwise
     }
     preReleases {
         on ~/main/ use { "beta" }
@@ -80,8 +80,8 @@ dependencies {
     implementation "org.dmfs:jems2:2.18.0"
 
     testImplementation project(":semver-confidence")
-    testImplementation 'org.saynotobugs:confidence-core:0.22.3'
-    testImplementation 'org.saynotobugs:confidence-incubator:0.22.3'
+    testImplementation 'org.saynotobugs:confidence-core:0.45.1'
+    testImplementation 'org.saynotobugs:confidence-incubator:0.45.1'
     testImplementation "org.dmfs:jems2-testing:2.18.0"
     testImplementation "org.dmfs:jems2-confidence:2.18.0"
     testImplementation "org.hamcrest:hamcrest:2.2"

--- a/semver-confidence/build.gradle
+++ b/semver-confidence/build.gradle
@@ -18,13 +18,13 @@ dependencies {
 
     api rootProject
     implementation 'org.dmfs:jems2:2.18.0'
-    implementation 'org.saynotobugs:confidence-core:0.22.3'
-    implementation 'org.saynotobugs:confidence-incubator:0.22.3'
+    implementation 'org.saynotobugs:confidence-core:0.45.1'
+    implementation 'org.saynotobugs:confidence-incubator:0.45.1'
     implementation 'org.dmfs:jems2-confidence:2.18.0'
 
     testImplementation 'org.dmfs:jems2:2.18.0'
     testImplementation 'org.dmfs:jems2-testing:2.18.0'
-    testImplementation 'org.saynotobugs:confidence-test:0.22.3'
+    testImplementation 'org.saynotobugs:confidence-test:0.45.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
 }

--- a/semver-confidence/src/main/java/org/dmfs/semver/confidence/FailsToParse.java
+++ b/semver-confidence/src/main/java/org/dmfs/semver/confidence/FailsToParse.java
@@ -1,0 +1,25 @@
+package org.dmfs.semver.confidence;
+
+import org.dmfs.semver.VersionParser;
+import org.dmfs.srcless.annotations.staticfactory.StaticFactories;
+import org.saynotobugs.confidence.description.Spaced;
+import org.saynotobugs.confidence.description.Text;
+import org.saynotobugs.confidence.description.Value;
+import org.saynotobugs.confidence.quality.composite.Has;
+import org.saynotobugs.confidence.quality.composite.QualityComposition;
+
+import static org.saynotobugs.confidence.core.quality.Object.throwing;
+
+
+@StaticFactories("SemVer")
+public final class FailsToParse extends QualityComposition<VersionParser>
+{
+    public FailsToParse(CharSequence versionString)
+    {
+        super(new Has<>(
+            new Spaced(new Text("fails to parse"), new Value(versionString)),
+            new Spaced(new Text("did not fail to parse"), new Value(versionString)),
+            v -> () -> v.parse(versionString),
+            throwing(IllegalArgumentException.class)));
+    }
+}

--- a/semver-confidence/src/main/java/org/dmfs/semver/confidence/Parses.java
+++ b/semver-confidence/src/main/java/org/dmfs/semver/confidence/Parses.java
@@ -1,0 +1,25 @@
+package org.dmfs.semver.confidence;
+
+import org.dmfs.semver.Version;
+import org.dmfs.semver.VersionParser;
+import org.dmfs.srcless.annotations.staticfactory.StaticFactories;
+import org.saynotobugs.confidence.Quality;
+import org.saynotobugs.confidence.description.Spaced;
+import org.saynotobugs.confidence.description.Text;
+import org.saynotobugs.confidence.description.Value;
+import org.saynotobugs.confidence.quality.composite.Has;
+import org.saynotobugs.confidence.quality.composite.QualityComposition;
+
+
+@StaticFactories("SemVer")
+public final class Parses extends QualityComposition<VersionParser>
+{
+    public Parses(CharSequence versionString, Quality<? super Version> versionQuality)
+    {
+        super(new Has<>(
+            new Spaced(new Text("parses"), new Value(versionString)),
+            new Spaced(new Text("parsed"), new Value(versionString)),
+            v -> v.parse(versionString),
+            versionQuality));
+    }
+}

--- a/semver-confidence/src/test/java/org/dmfs/semver/confidence/FailsToParseTest.java
+++ b/semver-confidence/src/test/java/org/dmfs/semver/confidence/FailsToParseTest.java
@@ -1,0 +1,22 @@
+package org.dmfs.semver.confidence;
+
+import org.dmfs.semver.Release;
+import org.saynotobugs.confidence.junit5.engine.Assertion;
+import org.saynotobugs.confidence.junit5.engine.Confidence;
+
+import static org.saynotobugs.confidence.core.quality.Composite.allOf;
+import static org.saynotobugs.confidence.junit5.engine.ConfidenceEngine.assertionThat;
+import static org.saynotobugs.confidence.test.quality.Quality.fails;
+import static org.saynotobugs.confidence.test.quality.Quality.passes;
+
+@Confidence
+class FailsToParseTest
+{
+    Assertion fails_to_parse = assertionThat(
+        new FailsToParse("a.b.c"),
+        allOf(
+            passes(s -> {throw new IllegalArgumentException("can't parse that");}),
+            fails(s -> new Release(1, 2, 3))
+        )
+    );
+}

--- a/semver-confidence/src/test/java/org/dmfs/semver/confidence/HasNoBuildTest.java
+++ b/semver-confidence/src/test/java/org/dmfs/semver/confidence/HasNoBuildTest.java
@@ -21,7 +21,7 @@ class HasNoBuildTest
         allOf(
             passes(mock(Version.class, with(Version::build, returning(new Absent<>())))),
             fails(mock(Version.class, with(Version::build, returning(new Present<>("123456")))),
-                describesAs(matchesPattern("had build <present <org\\.dmfs\\.jems2\\.optional\\.Present@.*> >"))),
+                describesAs(matchesPattern("had build <present \"123456\" >"))),
             hasDescription("has build <absent>")
         )
     );

--- a/semver-confidence/src/test/java/org/dmfs/semver/confidence/HasNoPreReleaseTest.java
+++ b/semver-confidence/src/test/java/org/dmfs/semver/confidence/HasNoPreReleaseTest.java
@@ -21,7 +21,7 @@ class HasNoPreReleaseTest
         allOf(
             passes(mock(Version.class, with(Version::preRelease, returning(new Absent<>())))),
             fails(mock(Version.class, with(Version::preRelease, returning(new Present<>("123456")))),
-                describesAs(matchesPattern("had preRelease <present <org\\.dmfs\\.jems2\\.optional\\.Present@.*> >"))),
+                describesAs(matchesPattern("had preRelease <present \"123456\" >"))),
             hasDescription("has preRelease <absent>")
         )
     );

--- a/semver-confidence/src/test/java/org/dmfs/semver/confidence/ParsesTest.java
+++ b/semver-confidence/src/test/java/org/dmfs/semver/confidence/ParsesTest.java
@@ -1,0 +1,23 @@
+package org.dmfs.semver.confidence;
+
+import org.saynotobugs.confidence.junit5.engine.Assertion;
+import org.saynotobugs.confidence.junit5.engine.Confidence;
+
+import static org.saynotobugs.confidence.core.quality.Composite.allOf;
+import static org.saynotobugs.confidence.core.quality.Grammar.to;
+import static org.saynotobugs.confidence.junit5.engine.ConfidenceEngine.assertionThat;
+import static org.saynotobugs.confidence.test.quality.Quality.fails;
+import static org.saynotobugs.confidence.test.quality.Quality.passes;
+
+@Confidence
+class ParsesTest
+{
+    Assertion parses_quality = assertionThat(
+        new Parses("1.2.3", to(new Release(1, 2, 3))),
+        allOf(
+            passes(s -> new org.dmfs.semver.Release(1, 2, 3)),
+            fails(s -> new org.dmfs.semver.Release(2, 3, 4)),
+            fails(s -> {throw new IllegalArgumentException("Not a version");})
+        )
+    );
+}

--- a/semver-confidence/src/test/java/org/dmfs/semver/confidence/PreReleaseTest.java
+++ b/semver-confidence/src/test/java/org/dmfs/semver/confidence/PreReleaseTest.java
@@ -49,7 +49,7 @@ class PreReleaseTest
                 with(Version::minor, returning(3)),
                 with(Version::patch, returning(2)),
                 with(Version::preRelease, returning(new Absent<>()))), "{ ...\n  had minor <3>\n  and\n  had patch <2>\n  and\n  had preRelease absent }"),
-            hasDescription("has major <1>\n  and\n  has minor <2>\n  and\n  has patch <3>\n  and\n  has preRelease present \"abc\""))
+            hasDescription("{ has major <1>\n  and\n  has minor <2>\n  and\n  has patch <3>\n  and\n  has preRelease present \"abc\" }"))
     );
 
     Assertion preRelease_with_qualities = assertionThat(
@@ -85,6 +85,6 @@ class PreReleaseTest
                 with(Version::minor, returning(3)),
                 with(Version::patch, returning(2)),
                 with(Version::preRelease, returning(new Absent<>()))), "{ ...\n  had minor <3>\n  and\n  had patch <2>\n  and\n  had preRelease absent }"),
-            hasDescription("has major <1>\n  and\n  has minor <2>\n  and\n  has patch <3>\n  and\n  has preRelease present \"abc\""))
+            hasDescription("{ has major <1>\n  and\n  has minor <2>\n  and\n  has patch <3>\n  and\n  has preRelease present \"abc\" }"))
     );
 }

--- a/semver-confidence/src/test/java/org/dmfs/semver/confidence/ReleaseTest.java
+++ b/semver-confidence/src/test/java/org/dmfs/semver/confidence/ReleaseTest.java
@@ -46,8 +46,8 @@ class ReleaseTest
                     with(Version::patch, returning(2)),
                     with(Version::preRelease, returning(new Present<>("123")))),
                 describesAs(matchesPattern(
-                    "\\{ ...\n  had minor <3>\n  and\n  had patch <2>\n  and\n  had preRelease <present <org\\.dmfs\\.jems2\\.optional\\.Present@.*> > \\}"))),
-            hasDescription("has major <1>\n  and\n  has minor <2>\n  and\n  has patch <3>\n  and\n  has preRelease <absent>"))
+                    "\\{ ...\n  had minor <3>\n  and\n  had patch <2>\n  and\n  had preRelease <present \"123\" > \\}"))),
+            hasDescription("{ has major <1>\n  and\n  has minor <2>\n  and\n  has patch <3>\n  and\n  has preRelease <absent> }"))
     );
 
     Assertion release_with_qualities = assertionThat(
@@ -79,7 +79,7 @@ class ReleaseTest
                     with(Version::patch, returning(2)),
                     with(Version::preRelease, returning(new Present<>("123")))),
                 describesAs(matchesPattern(
-                    "\\{ ...\n  had minor <3>\n  and\n  had patch <2>\n  and\n  had preRelease <present <org\\.dmfs\\.jems2\\.optional\\.Present@.*> > \\}"))),
-            hasDescription("has major <1>\n  and\n  has minor <2>\n  and\n  has patch <3>\n  and\n  has preRelease <absent>"))
+                    "\\{ ...\n  had minor <3>\n  and\n  had patch <2>\n  and\n  had preRelease <present \"123\" > \\}"))),
+            hasDescription("{ has major <1>\n  and\n  has minor <2>\n  and\n  has patch <3>\n  and\n  has preRelease <absent> }"))
     );
 }

--- a/semver-confidence/src/test/java/org/dmfs/semver/confidence/VersionThatTest.java
+++ b/semver-confidence/src/test/java/org/dmfs/semver/confidence/VersionThatTest.java
@@ -18,7 +18,7 @@ class VersionThatTest
         allOf(
             passes(mock(Version.class, with(Version::major, returning(1)))),
             fails(mock(Version.class, with(Version::major, returning(2))), "{ had major <2> }"),
-            hasDescription("has major <1>"))
+            hasDescription("{ has major <1> }"))
     );
 
     Assertion versionThat_with_multiple_delegates = assertionThat(
@@ -40,6 +40,6 @@ class VersionThatTest
                 with(Version::major, returning(1)),
                 with(Version::minor, returning(2)),
                 with(Version::patch, returning(2))), "{ ...\n  had patch <2> }"),
-            hasDescription("has major <1>\n  and\n  has minor <2>\n  and\n  has patch <3>"))
+            hasDescription("{ has major <1>\n  and\n  has minor <2>\n  and\n  has patch <3> }"))
     );
 }

--- a/src/main/java/org/dmfs/semver/StrictParser.java
+++ b/src/main/java/org/dmfs/semver/StrictParser.java
@@ -23,6 +23,6 @@ public final class StrictParser implements VersionParser
             throw new IllegalArgumentException(String.format("%s is not a valid Semantic Version String.", versionString));
         }
         return new StructuredVersion(parseInt(matcher.group(1)), parseInt(matcher.group(2)), parseInt(matcher.group(3)),
-            new NullSafe<>(matcher.group(4)), new NullSafe<>(matcher.group(4)));
+            new NullSafe<>(matcher.group(4)), new NullSafe<>(matcher.group(5)));
     }
 }

--- a/src/test/java/org/dmfs/semver/StrictParserTest.java
+++ b/src/test/java/org/dmfs/semver/StrictParserTest.java
@@ -1,33 +1,67 @@
 package org.dmfs.semver;
 
-import org.junit.jupiter.api.Test;
+import org.saynotobugs.confidence.junit5.engine.Assertion;
+import org.saynotobugs.confidence.junit5.engine.Confidence;
 
-import static org.dmfs.jems2.hamcrest.matchers.fragile.BrokenFragileMatcher.throwing;
-import static org.dmfs.semver.Matchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.dmfs.semver.confidence.SemVer.*;
+import static org.saynotobugs.confidence.core.quality.Composite.allOf;
+import static org.saynotobugs.confidence.core.quality.Grammar.to;
+import static org.saynotobugs.confidence.junit5.engine.ConfidenceEngine.assertionThat;
 
 
+@Confidence
 class StrictParserTest
 {
+    Assertion parses_releases =
+        assertionThat(new StrictParser(),
+            allOf(
+                parses("1.2.3", to(
+                    allOf(
+                        release(1, 2, 3),
+                        hasNoBuild()))),
+                parses("123.456.789", to(
+                    allOf(
+                        release(123, 456, 789),
+                        hasNoBuild())))));
 
-    @Test
-    void test()
-    {
-        assertThat(new StrictParser().parse("1.0.0"),
-            is(release(1, 0, 0)));
-        assertThat(new StrictParser().parse("1.0.0-alpha"),
-            is(preRelease(version(1, 0, 0), "alpha")));
-        assertThat(new StrictParser().parse("1.0.0-alpha+build"),
-            is(preRelease(version(1, 0, 0), "alpha")));
-        assertThat(new StrictParser().parse("1.0.0-alpha-123"),
-            is(preRelease(version(1, 0, 0), "alpha-123")));
-        assertThat(new StrictParser().parse("1.0.0-alpha.123"),
-            is(preRelease(version(1, 0, 0), "alpha.123")));
+    Assertion parses_pre_releases =
+        assertionThat(new StrictParser(),
+            allOf(
+                parses("2.3.4-alpha", to(
+                    allOf(
+                        preRelease(2, 3, 4, "alpha"),
+                        hasNoBuild()))),
+                parses("2.3.4-alpha-567", to(
+                    allOf(
+                        preRelease(2, 3, 4, "alpha-567"),
+                        hasNoBuild()))),
+                parses("2.3.4-alpha.567", to(
+                    allOf(
+                        preRelease(2, 3, 4, "alpha.567"),
+                        hasNoBuild())))));
 
-        assertThat(() -> new StrictParser().parse("1.0.a-alpha-123"),
-            is(throwing(IllegalArgumentException.class)));
+    Assertion parses_build =
+        assertionThat(new StrictParser(),
+            allOf(
+                parses("3.4.5-alpha+build", to(
+                    allOf(
+                        preRelease(3, 4, 5, "alpha"),
+                        hasBuild("build")))),
+                parses("3.4.5-alpha-123+build-1", to(
+                    allOf(
+                        preRelease(3, 4, 5, "alpha-123"),
+                        hasBuild("build-1")))),
+                parses("3.4.5-alpha.123+build.1", to(
+                    allOf(
+                        preRelease(3, 4, 5, "alpha.123"),
+                        hasBuild("build.1"))))));
 
-    }
-
+    Assertion fails_to_parse_invalid_versions =
+        assertionThat(new StrictParser(),
+            allOf(
+                failsToParse("1"),
+                failsToParse("1.2"),
+                failsToParse("1.2.a"),
+                failsToParse("1.2.3.4"),
+                failsToParse("1.0.a-alpha-123")));
 }


### PR DESCRIPTION
The build part was always set to the pre-release part. This is fixed now.